### PR TITLE
Configure for remote build: update azure.yaml and add missing .funcignore

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -9,11 +9,13 @@ services:
     project: ./packages/burger-api
     language: ts
     host: function
+    remoteBuild: true
 
   burger-mcp:
     project: ./packages/burger-mcp
     language: ts
     host: function
+    remoteBuild: true
 
   burger-webapp:
     project: ./packages/burger-webapp
@@ -29,6 +31,7 @@ services:
     project: ./packages/agent-api
     language: ts
     host: function
+    remoteBuild: true
 
   agent-webapp:
     project: ./packages/agent-webapp

--- a/packages/burger-mcp/.funcignore
+++ b/packages/burger-mcp/.funcignore
@@ -1,0 +1,16 @@
+.vscode/
+.azure/
+.azurite/
+.genaiscript/
+test/
+docs/
+infra/
+node_modules/
+*.js.map
+.git*
+*.env*
+TODO
+/*.http
+azure.yaml
+local.settings.json
+README.md


### PR DESCRIPTION
## Summary

Configures the project for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under all 3 function services (`burger-api`, `burger-mcp`, `agent-api`)
- **packages/burger-mcp/.funcignore**: Created missing `.funcignore` file with `node_modules` ignored (matching the pattern from the other function packages)

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. Adding `remoteBuild: true` explicitly opts into this behavior. The `burger-mcp` package was missing a `.funcignore` file entirely, which means all files including `node_modules` would be uploaded during deployment.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.